### PR TITLE
Add CMYK accent bars and show revealed article images in color

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,6 +27,12 @@
   --pastel-yellow-border: #ddd9d4;
   --pastel-blue: #f0f2f4;
   --pastel-blue-border: #d4d9dd;
+
+  /* CMYK color bars */
+  --cmyk-cyan: #00a3d6;
+  --cmyk-magenta: #e4007c;
+  --cmyk-yellow: #ffd400;
+  --cmyk-black: #111111;
 }
 
 /* Dark theme overrides */
@@ -56,6 +62,11 @@
   --pastel-yellow-border: #3a3424;
   --pastel-blue: #11161c;
   --pastel-blue-border: #263343;
+
+  --cmyk-cyan: #22b8e0;
+  --cmyk-magenta: #ff4aa2;
+  --cmyk-yellow: #ffde44;
+  --cmyk-black: #0b0b0b;
 }
 
 @theme inline {
@@ -139,6 +150,37 @@ a:hover {
   margin-bottom: 2rem;
 }
 
+.cmyk-bars {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.35rem;
+  margin: 1rem auto 0;
+  max-width: 360px;
+}
+
+.cmyk-bar {
+  height: 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--ink-black);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+}
+
+.cmyk-bar.cyan {
+  background: var(--cmyk-cyan);
+}
+
+.cmyk-bar.magenta {
+  background: var(--cmyk-magenta);
+}
+
+.cmyk-bar.yellow {
+  background: var(--cmyk-yellow);
+}
+
+.cmyk-bar.black {
+  background: var(--cmyk-black);
+}
+
 /* Button styling */
 button, .button {
   font-family: "Times New Roman", Times, serif;
@@ -186,5 +228,10 @@ img {
 }
 
 img:hover {
+  filter: grayscale(0%);
+}
+
+.color-image,
+.color-image:hover {
   filter: grayscale(0%);
 }

--- a/src/components/ArticleDetails.tsx
+++ b/src/components/ArticleDetails.tsx
@@ -33,6 +33,7 @@ export default function ArticleDetails({ title, snippet, imageUrl }: ArticleDeta
             <img 
               src={imageUrl} 
               alt={title}
+              className="color-image"
               style={{ 
                 width: '100%',
                 height: 'auto',

--- a/src/components/GameCompletion.tsx
+++ b/src/components/GameCompletion.tsx
@@ -90,6 +90,12 @@ export default function GameCompletion({
         }}>
           Final Score: {score} out of {totalArticles} correct
         </div>
+        <div className="cmyk-bars" aria-hidden="true">
+          <span className="cmyk-bar cyan" />
+          <span className="cmyk-bar magenta" />
+          <span className="cmyk-bar yellow" />
+          <span className="cmyk-bar black" />
+        </div>
       </div>
       
       {/* Show all results */}


### PR DESCRIPTION
### Motivation

- Introduce a subtle CMYK accent to the results header to match the print-newspaper aesthetic.
- Allow revealed article images to display in full color while keeping the default newspaper grayscale effect.
- Ensure the accents are theme-aware so they render nicely in both light and dark modes.
- Keep the changes small and UI-only so they can be reverted easily.

### Description

- Added CMYK CSS variables and dark-theme overrides in `src/app/globals.css` (`--cmyk-cyan`, `--cmyk-magenta`, `--cmyk-yellow`, `--cmyk-black`).
- Implemented `.cmyk-bars` and `.cmyk-bar` styles in `src/app/globals.css` and rendered the CMYK markup in the results header in `src/components/GameCompletion.tsx` with `aria-hidden="true"`.
- Added a `.color-image` utility to `src/app/globals.css` and applied `className="color-image"` to the image in `src/components/ArticleDetails.tsx` so revealed images bypass the grayscale filter.
- Changes were committed on branch `cmyk-color-bars`.

### Testing

- No automated tests or CI runs were executed for this change.
- Dev server or visual capture was not performed in this rollout, and previous attempts were blocked by missing Supabase environment variables (`NEXT_PUBLIC_SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`).
- Basic static edits were validated by creating the branch and committing the updated files locally.
- No unit tests or lint runs were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bd5a4698c832a9a96c042641f2bc6)