### PR TITLE
Enhance puzzle and results UI with color accents

### DIFF
--- a/src/components/ArticleResult.tsx
+++ b/src/components/ArticleResult.tsx
@@ -10,7 +10,8 @@ export default function ArticleResult({ wasCorrect, userGuess }: ArticleResultPr
       backgroundColor: wasCorrect ? 'var(--pastel-green)' : 'var(--pastel-red)', 
       border: `3px solid ${wasCorrect ? 'var(--pastel-green-border)' : 'var(--pastel-red-border)'}`,
       textAlign: 'center',
-      borderLeft: `6px solid ${wasCorrect ? 'var(--newspaper-blue)' : 'var(--accent-red)'}`
+      borderLeft: `6px solid ${wasCorrect ? 'var(--newspaper-blue)' : 'var(--accent-red)'}`,
+      position: 'relative'
     }}>
       {wasCorrect ? (
         <div>
@@ -57,12 +58,15 @@ export default function ArticleResult({ wasCorrect, userGuess }: ArticleResultPr
       )}
       <div
         style={{
-          marginTop: '0.75rem',
-          fontSize: '1.2rem',
-          fontWeight: 'bold',
+          position: 'absolute',
+          right: '0.75rem',
+          bottom: '0.65rem',
+          fontSize: '0.7rem',
+          fontWeight: 600,
           color: wasCorrect ? 'var(--newspaper-blue)' : 'var(--accent-red)',
           textTransform: 'uppercase',
-          letterSpacing: '0.08em'
+          letterSpacing: '0.12em',
+          opacity: 0.6
         }}
       >
         {wasCorrect ? 'Verified' : 'Correction Issued'}

--- a/src/components/ArticleResult.tsx
+++ b/src/components/ArticleResult.tsx
@@ -9,7 +9,8 @@ export default function ArticleResult({ wasCorrect, userGuess }: ArticleResultPr
       padding: 'clamp(1rem, 3vw, 1.5rem)', 
       backgroundColor: wasCorrect ? 'var(--pastel-green)' : 'var(--pastel-red)', 
       border: `3px solid ${wasCorrect ? 'var(--pastel-green-border)' : 'var(--pastel-red-border)'}`,
-      textAlign: 'center'
+      textAlign: 'center',
+      borderLeft: `6px solid ${wasCorrect ? 'var(--newspaper-blue)' : 'var(--accent-red)'}`
     }}>
       {wasCorrect ? (
         <div>
@@ -54,6 +55,18 @@ export default function ArticleResult({ wasCorrect, userGuess }: ArticleResultPr
           </p>
         </div>
       )}
+      <div
+        style={{
+          marginTop: '0.75rem',
+          fontSize: '1.2rem',
+          fontWeight: 'bold',
+          color: wasCorrect ? 'var(--newspaper-blue)' : 'var(--accent-red)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.08em'
+        }}
+      >
+        {wasCorrect ? 'Verified' : 'Correction Issued'}
+      </div>
     </div>
   )
 }

--- a/src/components/GameCompletion.tsx
+++ b/src/components/GameCompletion.tsx
@@ -108,8 +108,19 @@ export default function GameCompletion({
             marginBottom: '1.5rem', 
             padding: '1.5rem', 
             border: `2px solid ${state.wasCorrect ? 'var(--pastel-green-border)' : 'var(--pastel-red-border)'}`,
-            backgroundColor: state.wasCorrect ? 'var(--pastel-green)' : 'var(--pastel-red)'
+            backgroundColor: state.wasCorrect ? 'var(--pastel-green)' : 'var(--pastel-red)',
+            position: 'relative',
+            overflow: 'hidden'
           }}>
+            <div style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: '4px',
+              background: state.wasCorrect ? 'var(--newspaper-blue)' : 'var(--accent-red)',
+              opacity: 0.6
+            }} />
             <div style={{ 
               display: 'flex', 
               justifyContent: 'space-between', 
@@ -133,7 +144,10 @@ export default function GameCompletion({
                   {state.article.title}
                 </a>
               </strong>
-              <span style={{ fontSize: '1.5rem' }}>
+              <span style={{ 
+                fontSize: '1.5rem',
+                color: state.wasCorrect ? 'var(--newspaper-blue)' : 'var(--accent-red)'
+              }}>
                 {state.wasCorrect ? '✓' : '✗'}
               </span>
             </div>
@@ -146,7 +160,7 @@ export default function GameCompletion({
               <div style={{ 
                 marginTop: '1rem',
                 padding: '1rem',
-                backgroundColor: 'var(--paper-white)',
+                backgroundColor: 'var(--pastel-yellow)',
                 border: '1px solid var(--border-gray)'
               }}>
                 <div style={{ marginBottom: '0.5rem' }}>

--- a/src/components/GameComponent.tsx
+++ b/src/components/GameComponent.tsx
@@ -18,18 +18,29 @@ interface GameComponentProps {
 
 export default function GameComponent({ puzzleDate, isArchive = false }: GameComponentProps) {
   const [error, setError] = useState<string | null>(null)
-  const categoryAccents = [
-    'var(--accent-red)',
-    'var(--newspaper-blue)',
-    'var(--gold-highlight)',
-    'var(--cmyk-cyan)'
-  ]
-  const categoryTints = [
-    'var(--pastel-yellow)',
-    'var(--pastel-blue)',
-    'var(--newsprint-gray)',
-    'var(--pastel-green)'
-  ]
+  const getCategoryAccent = (index: number, total: number) => {
+    if (total <= 1) {
+      return 'var(--cmyk-cyan)'
+    }
+    const colors = [
+      'var(--cmyk-cyan)',
+      'var(--cmyk-magenta)',
+      'var(--cmyk-yellow)',
+      'var(--cmyk-black)'
+    ]
+    const maxIndex = total - 1
+    const progress = index / maxIndex
+    const segmentSize = 1 / (colors.length - 1)
+    const segmentIndex = Math.min(
+      colors.length - 2,
+      Math.floor(progress / segmentSize)
+    )
+    const segmentProgress = (progress - segmentIndex * segmentSize) / segmentSize
+    const fromColor = colors[segmentIndex]
+    const toColor = colors[segmentIndex + 1]
+    const percent = Math.round(segmentProgress * 100)
+    return `color-mix(in srgb, ${fromColor} ${100 - percent}%, ${toColor} ${percent}%)`
+  }
   
   const onError = useCallback((errorMessage: string) => {
     if (isArchive) {
@@ -156,9 +167,9 @@ export default function GameComponent({ puzzleDate, isArchive = false }: GameCom
                   {currentArticle.article.categories.map((category, idx) => (
                     <div key={idx} style={{ 
                       display: 'inline-block',
-                      backgroundColor: categoryTints[idx % categoryTints.length],
+                      backgroundColor: 'var(--newsprint-gray)',
                       border: '1px solid var(--border-gray)',
-                      borderTop: `3px solid ${categoryAccents[idx % categoryAccents.length]}`,
+                      borderTop: `3px solid ${getCategoryAccent(idx, currentArticle.article.categories.length)}`,
                       borderRadius: '0.25rem',
                       padding: '0.5rem 1rem',
                       fontSize: '1.1rem',

--- a/src/components/GameComponent.tsx
+++ b/src/components/GameComponent.tsx
@@ -18,6 +18,18 @@ interface GameComponentProps {
 
 export default function GameComponent({ puzzleDate, isArchive = false }: GameComponentProps) {
   const [error, setError] = useState<string | null>(null)
+  const categoryAccents = [
+    'var(--accent-red)',
+    'var(--newspaper-blue)',
+    'var(--gold-highlight)',
+    'var(--cmyk-cyan)'
+  ]
+  const categoryTints = [
+    'var(--pastel-yellow)',
+    'var(--pastel-blue)',
+    'var(--newsprint-gray)',
+    'var(--pastel-green)'
+  ]
   
   const onError = useCallback((errorMessage: string) => {
     if (isArchive) {
@@ -129,7 +141,8 @@ export default function GameComponent({ puzzleDate, isArchive = false }: GameCom
                   fontSize: '1.35rem',
                   marginBottom: '1rem',
                   fontStyle: 'italic',
-                  color: 'var(--text-gray)'
+                  color: 'var(--newspaper-blue)',
+                  opacity: 0.85
                 }}>
                   Identify the article:
                 </h3>
@@ -143,8 +156,9 @@ export default function GameComponent({ puzzleDate, isArchive = false }: GameCom
                   {currentArticle.article.categories.map((category, idx) => (
                     <div key={idx} style={{ 
                       display: 'inline-block',
-                      backgroundColor: 'var(--newsprint-gray)',
+                      backgroundColor: categoryTints[idx % categoryTints.length],
                       border: '1px solid var(--border-gray)',
+                      borderTop: `3px solid ${categoryAccents[idx % categoryAccents.length]}`,
                       borderRadius: '0.25rem',
                       padding: '0.5rem 1rem',
                       fontSize: '1.1rem',


### PR DESCRIPTION
### Motivation
- Improve visual clarity and feedback by introducing ink-like accent borders and pastel tints to category chips and result banners.
- Make success and failure states more distinct and visually informative with colored ribbons and status labels.

### Description
- Add `categoryAccents` and `categoryTints` arrays and apply them to category chips in `src/components/GameComponent.tsx`, update heading color and opacity.
- Update `src/components/ArticleResult.tsx` to add a left accent border and a status label (`Verified` / `Correction Issued`) with color variations for correct/incorrect outcomes.
- Enhance `src/components/GameCompletion.tsx` with a top colored ribbon, colored check/✗ icons, and a warmer reveal panel background for incorrect answers.

### Testing
- Started the dev server with `npm run dev` and confirmed the app compiled and served the `/game` page (HTTP 200).
- Playwright script navigated to `/game` and captured screenshots which were saved as artifacts, and the script completed successfully on a follow-up run.
- The API route `/api/puzzle/[date]` returned 500 errors due to a missing environment variable `NEXT_PUBLIC_SUPABASE_URL`, so some API requests failed during the run.
- No unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c0f8418c8832a8cd4ffb9004588ad)